### PR TITLE
API Improvements

### DIFF
--- a/safe/api.py
+++ b/safe/api.py
@@ -198,7 +198,14 @@ class APICollection(object):
 
     search = deprecated('Method renamed to find')(find)
 
+    def get(self, key, default=None):
+        if key not in self.keys():
+            return default
+        return self.api.get_child(key)
+
     def __getitem__(self, key):
+        if key not in self.keys():
+            raise KeyError(key)
         return self.api.get_child(key)
 
     def __contains__(self, key):


### PR DESCRIPTION
Any feedback @tgoodlet @terrkerr?
- The `KeyError` change should go in (it should have been there from the start) but might break some stuff in our wrappers.
- The `findpath` helper will be useful for comparability:

``` python
network_ip = api.findpath('network.ip')
cluster_ip = api.findpath('cluster.floating_ip')

if cluster_ip:
    # ...
```
