### PR TITLE
Handle "reason" of type string.

### DIFF
--- a/safe/library.py
+++ b/safe/library.py
@@ -15,11 +15,19 @@ class APIError(requests.HTTPError):
 
 class Reason(object):
     def __init__(self, reason):
-        self.name = reason.get('obj_name')
-        self.obj = reason['obj_type']
-        self.description = reason['description']
-        self.module = reason['module']
-        self.url = reason.get('url')
+        # if it's a string, just treat it as the error description
+        if isinstance(reason, six.string_types):
+            self.name = ''
+            self.obj = ''
+            self.description = reason
+            self.module = ''
+            self.url = ''
+        else:
+            self.name = reason.get('obj_name')
+            self.obj = reason['obj_type']
+            self.description = reason['description']
+            self.module = reason['module']
+            self.url = reason.get('url')
 
     def __str__(self):
         return self.description


### PR DESCRIPTION
Not much to do if we only get a string as the reason, thus use it directly as the description. It seems to properly work in the cases where I hit it (fail to apply network config because we were unable to find all dynamic IPs).
