### PR TITLE
Handle "reason" of type string (agora vai!)

### DIFF
--- a/safe/library.py
+++ b/safe/library.py
@@ -105,7 +105,10 @@ def raise_from_json(r):
             # Just a regular failure
             return APIError(reasons, response=r)
         elif reasons:
-            explanation = [Reason(reason) for reason in reasons]
+            explanation = [
+                reason if isinstance(reason, six.string_types) else Reason(reason)
+                     for reason in reasons
+            ]
             return CommitFailed(explanation, response=r)
 
         status = error.get('status')

--- a/tests/test_exception_wrapping.py
+++ b/tests/test_exception_wrapping.py
@@ -135,6 +135,22 @@ def test_sngms_fwupdate_exception():
     assert str(exception) == error_message
 
 
+def test_network_apply_exception():
+    error_message = 'Apply changes failed: Cannot get DHCP IPv4 on eth1.\nCannot get DHCP IPv6 on eth1.'
+    response = MockResponse({
+        'status': False,
+        'method': 'apply',
+        'module': 'network',
+        'error': {
+            'message': ['Apply Network changes failed.'],
+            'reason': ['Cannot get DHCP IPv4 on eth1.', 'Cannot get DHCP IPv6 on eth1.']
+        }
+    })
+
+    exception = safe.library.raise_from_json(response)
+    assert str(exception) == error_message
+
+
 def test_commit_failed_exception():
     error_message = 'Default ipv4 gateway is not on eth0 subnet'
     response = MockResponse({


### PR DESCRIPTION
Based on feedback from #6 and changes on [8118aa7](https://github.com/sangoma/safepy2/commit/8118aa71e47fd40a7c4bc309766659e5f661a056) , I tried to follow the current code organization, restricting most of the processing logic on the `raise_from_json` function - which ended up simplifying the code a bit as I realize we don't really need a `Reason` object there (as far as the library code is concerned).

Let me know if you are merging (or not) these changes, as I'll need this on our NSC branch next week.
