### PR TITLE
Handle "errors" as a list of dictionaries.

### DIFF
--- a/safe/library.py
+++ b/safe/library.py
@@ -98,7 +98,11 @@ def raise_from_json(r):
     error = data.get('error')
     message = None
     if isinstance(error, list):
-        message = '\n'.join(error)
+        if isinstance(next(iter(error), None), dict):
+            msglist = '\n'.join('{module} - {obj_type} - {description} - {type}'.format(**e) for e in error)
+            message = 'Failed to apply changes: {0}'.format(msglist)
+        else:
+            message = '\n'.join(error)
     elif isinstance(error, dict):
         reasons = error.get('reason')
         if isinstance(reasons, six.string_types):

--- a/tests/test_exception_wrapping.py
+++ b/tests/test_exception_wrapping.py
@@ -152,6 +152,29 @@ def test_network_apply_exception():
     assert str(exception) == 'Apply changes failed: ' + '\n'.join(reasons)
 
 
+def test_apply_dict_list_exception():
+    reasons = [
+        'Configuration Manager - file update - vars_additional.xml - OK',
+        'Configuration Manager - file update - autoload_configs/logfile.conf.xml - OK'
+    ]
+
+    response = MockResponse({
+        'status': False,
+        'type': 'archive',
+        'method': 'restore',
+        'module': 'nsc',
+        'error': [
+            { 'module': 'Configuration Manager', 'obj_type': 'file update',
+              'description': 'vars_additional.xml', 'type': 'OK' },
+            { 'module': 'Configuration Manager', 'obj_type': 'file update',
+              'description': 'autoload_configs/logfile.conf.xml', 'type': 'OK' }
+        ]
+    })
+
+    exception = safe.library.raise_from_json(response)
+    assert str(exception) == 'Failed to apply changes: ' + '\n'.join(reasons)
+
+
 def test_commit_failed_exception():
     error_message = 'Default ipv4 gateway is not on eth0 subnet'
     response = MockResponse({


### PR DESCRIPTION
This error can be reported when the system fails to apply configuration changes.

It can happen either when running configuration apply or restoring from a backup and some error happen during one of the steps.